### PR TITLE
Remove s390x from release binaries

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,7 +15,6 @@ builds:
       - amd64
       - arm
       - arm64
-      - s390x
     goarm:
       - 6
       - 7


### PR DESCRIPTION
It causes upx to fail:

⨯ release failed after 654.87s error=post hook failed: "                       Ultimate Packer for eXecutables\n                          Copyright (C) 1996 - 2017\nUPX 3.94        Markus Oberhumer, Laszlo Molnar & John Reiser   May 12th 2017\n\n        File size         Ratio      Format      Name\n   --------------------   ------   -----------   -----------\nupx: /home/runner/work/observatorium-otelcol/observatorium-otelcol/dist/opentelemetry-collector_linux_s390x/observatorium-otelcol: UnknownExecutableFormatException\n\nPacked 0 files.\n": exit status 1

﻿Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
